### PR TITLE
Add hover style to product labels

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,39 +24,39 @@
     <h2 class="text-xl font-semibold mb-4">Selecione os produtos:</h2>
 
         <div class="space-y-2">
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="alcohol-bialcohol" class="mr-2"> Alcohol al 70% Bialcohol 1L</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="arroz-gallo" class="mr-2"> Arroz largo fino Gallo 1kg</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="batatas-mccain" class="mr-2"> Papas fritas tradicionales cortadas MCCAIN 700g</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="chimichurri-alicante" class="mr-2"> Condimento para chimichurri Alicante sobre 50g</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="dulce-leche" class="mr-2"> Dulce de leche La Serenísima Colonial</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="empanadas-jamon-queso" class="mr-2"> Empanadas congeladas de jamón y queso</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="fideos-espaguetis" class="mr-2"> Fideos espaguetis MATARAZZO 500g</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="frambuesas-fra-nui" class="mr-2"> Frambuesas Fra-Nui bañadas en chocolate con leche 150g</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="alcohol-bialcohol" class="mr-2"> Alcohol al 70% Bialcohol 1L</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="arroz-gallo" class="mr-2"> Arroz largo fino Gallo 1kg</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="batatas-mccain" class="mr-2"> Papas fritas tradicionales cortadas MCCAIN 700g</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="chimichurri-alicante" class="mr-2"> Condimento para chimichurri Alicante sobre 50g</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="dulce-leche" class="mr-2"> Dulce de leche La Serenísima Colonial</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="empanadas-jamon-queso" class="mr-2"> Empanadas congeladas de jamón y queso</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="fideos-espaguetis" class="mr-2"> Fideos espaguetis MATARAZZO 500g</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="frambuesas-fra-nui" class="mr-2"> Frambuesas Fra-Nui bañadas en chocolate con leche 150g</label>
                 <div class="flex flex-col">
-                    <label class="flex items-center">
+                    <label class="flex items-center hover:underline cursor-pointer">
                         <input type="checkbox" name="produtos" value="coca-cola" class="mr-2 toggle-coca">
                         Gaseosa Coca-Cola Zero
                     </label>
                         <div class="ml-6 mt-2 hidden coca-options">
-                            <label class="flex items-center">
+                            <label class="flex items-center hover:underline cursor-pointer">
                                 <input type="radio" name="coca-cola-tamano" value="2.25L" class="mr-2"> 2,25 L
                                 </label>
-                                <label class="flex items-center">
+                                <label class="flex items-center hover:underline cursor-pointer">
                                 <input type="radio" name="coca-cola-tamano" value="1.75L" class="mr-2"> 1,75 L
                             </label>
                         </div>
                 </div>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="jabon-dove" class="mr-2"> Jabón exfoliante Dove 90g</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="jabon-palmolive" class="mr-2"> Jabón líquido para manos PALMOLIVE Naturals Camelia 500ml</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="lays" class="mr-2"> Papas fritas clásicas Lays 330g</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="leche-serenisima" class="mr-2"> Leche larga vida parcialmente descremada La Serenísima 1% 1L</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="pan-bimbo" class="mr-2"> Pan lacteado blanco rebanado grande Bimbo 610g</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="papel-elite" class="mr-2"> Papel higiénico doble hoja ultra suave ELITE 50m x4 unidades</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="pimenton-alicante" class="mr-2"> Pimentón seleccionado dulce Alicante pote 200g</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="rollos-felpita" class="mr-2"> Rollos de cocina FELPITA 120 paños paquete x3 unidades</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="toallitas-ayudin" class="mr-2"> Toallitas desinfectantes Ayudín aroma fresco 36 unidades</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="tortillas-rapiditas" class="mr-2"> Tortillas Light Rapiditas 10 unidades</label>
-            <label class="flex items-center"><input type="checkbox" name="produtos" value="yogur-griego" class="mr-2"> Yogur griego con frutilla y crema YOGURISIMO 125g</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="jabon-dove" class="mr-2"> Jabón exfoliante Dove 90g</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="jabon-palmolive" class="mr-2"> Jabón líquido para manos PALMOLIVE Naturals Camelia 500ml</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="lays" class="mr-2"> Papas fritas clásicas Lays 330g</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="leche-serenisima" class="mr-2"> Leche larga vida parcialmente descremada La Serenísima 1% 1L</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="pan-bimbo" class="mr-2"> Pan lacteado blanco rebanado grande Bimbo 610g</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="papel-elite" class="mr-2"> Papel higiénico doble hoja ultra suave ELITE 50m x4 unidades</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="pimenton-alicante" class="mr-2"> Pimentón seleccionado dulce Alicante pote 200g</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="rollos-felpita" class="mr-2"> Rollos de cocina FELPITA 120 paños paquete x3 unidades</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="toallitas-ayudin" class="mr-2"> Toallitas desinfectantes Ayudín aroma fresco 36 unidades</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="tortillas-rapiditas" class="mr-2"> Tortillas Light Rapiditas 10 unidades</label>
+            <label class="flex items-center hover:underline cursor-pointer"><input type="checkbox" name="produtos" value="yogur-griego" class="mr-2"> Yogur griego con frutilla y crema YOGURISIMO 125g</label>
         </div>
 
 


### PR DESCRIPTION
## Summary
- add `hover:underline cursor-pointer` styles to product labels in the form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532a005f8c832a9c410b67aa9e821a