### PR TITLE
Add scraping workflow for product comparison

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, request
+from scrapers import fetch_total_coto, fetch_total_carrefour
 
 app = Flask(__name__)
 
@@ -9,7 +10,16 @@ def index():
 @app.route('/comparar', methods=['POST'])
 def comparar():
     produtos_selecionados = request.form.getlist('produtos')
-    return f"Produtos selecionados: {', '.join(produtos_selecionados)}"
+
+    total_coto = fetch_total_coto(produtos_selecionados)
+    total_carrefour = fetch_total_carrefour(produtos_selecionados)
+
+    return render_template(
+        'resultado.html',
+        produtos=produtos_selecionados,
+        total_coto=total_coto,
+        total_carrefour=total_carrefour,
+    )
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/scrapers.py
+++ b/scrapers.py
@@ -1,0 +1,89 @@
+import os
+from typing import List
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+
+def _init_driver() -> webdriver.Chrome:
+    """Initializes a Chrome WebDriver."""
+    options = webdriver.ChromeOptions()
+    options.add_argument("--headless")
+    return webdriver.Chrome(options=options)
+
+
+def fetch_total_coto(produtos: List[str]) -> float:
+    """Logs into Coto Digital, adds products to the cart and returns the total."""
+    dni = os.getenv("COTO_DNI")
+    password = os.getenv("COTO_PASSWORD")
+    if not dni or not password:
+        raise ValueError("Coto credentials not configured")
+
+    driver = _init_driver()
+    wait = WebDriverWait(driver, 10)
+    total = 0.0
+    try:
+        driver.get("https://www.cotodigital.com.ar/sitios/cdigi/")
+
+        # Login process
+        wait.until(EC.element_to_be_clickable((By.CSS_SELECTOR, "a.login-btn"))).click()
+        wait.until(EC.visibility_of_element_located((By.NAME, "username"))).send_keys(dni)
+        wait.until(EC.visibility_of_element_located((By.NAME, "password"))).send_keys(password + Keys.RETURN)
+
+        # Search and add each product
+        for produto in produtos:
+            search = wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, "input.search")))
+            search.clear()
+            search.send_keys(produto)
+            search.send_keys(Keys.RETURN)
+            add = wait.until(EC.element_to_be_clickable((By.CSS_SELECTOR, "button.add-to-cart")))
+            add.click()
+
+        # Go to cart and read the total cost
+        wait.until(EC.element_to_be_clickable((By.CSS_SELECTOR, "a.cart"))).click()
+        total_text = wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, "span.total-price"))).text
+        total = float(total_text.replace("$", "").replace(",", "."))
+    finally:
+        driver.quit()
+
+    return total
+
+
+def fetch_total_carrefour(produtos: List[str]) -> float:
+    """Logs into MiCarrefour, adds products to the cart and returns the total."""
+    email = os.getenv("CARREFOUR_EMAIL")
+    password = os.getenv("CARREFOUR_PASSWORD")
+    if not email or not password:
+        raise ValueError("Carrefour credentials not configured")
+
+    driver = _init_driver()
+    wait = WebDriverWait(driver, 10)
+    total = 0.0
+    try:
+        driver.get("https://www.carrefour.com.ar/")
+
+        # Login process
+        wait.until(EC.element_to_be_clickable((By.CSS_SELECTOR, "a.login"))).click()
+        wait.until(EC.visibility_of_element_located((By.NAME, "email"))).send_keys(email)
+        wait.until(EC.visibility_of_element_located((By.NAME, "password"))).send_keys(password + Keys.RETURN)
+
+        # Search and add each product
+        for produto in produtos:
+            search = wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, "input.search")))
+            search.clear()
+            search.send_keys(produto)
+            search.send_keys(Keys.RETURN)
+            add = wait.until(EC.element_to_be_clickable((By.CSS_SELECTOR, "button.add-to-cart")))
+            add.click()
+
+        # Go to cart and read the total cost
+        wait.until(EC.element_to_be_clickable((By.CSS_SELECTOR, "a.cart"))).click()
+        total_text = wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, "span.total-price"))).text
+        total = float(total_text.replace("$", "").replace(",", "."))
+    finally:
+        driver.quit()
+
+    return total

--- a/templates/resultado.html
+++ b/templates/resultado.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Resultados</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex flex-col items-center p-6">
+    <h1 class="text-3xl font-bold mb-6 text-center">Resultados de la comparación</h1>
+    <div class="bg-white shadow-md rounded p-6 w-full max-w-md">
+        <p class="mb-4">Productos: {{ ', '.join(produtos) }}</p>
+        <p class="mb-2">Total Coto: ${{ total_coto }}</p>
+        <p class="mb-2">Total Carrefour: ${{ total_carrefour }}</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement Selenium-based scrapers using env vars
- compare totals from Coto and Carrefour when checking out
- show the comparison in a new results page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532a9a7898832aa5827ec839a19dcd